### PR TITLE
use ActiveSupport::Reloader for Redmine4 (Rails5)

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -23,7 +23,7 @@ Redmine::Plugin.register :redmine_slack do
 		:partial => 'settings/slack_settings'
 end
 
-ActionDispatch::Callbacks.to_prepare do
+((Rails.version > "5")? ActiveSupport::Reloader : ActionDispatch::Callbacks).to_prepare do
 	require_dependency 'issue'
 	unless Issue.included_modules.include? RedmineSlack::IssuePatch
 		Issue.send(:include, RedmineSlack::IssuePatch)


### PR DESCRIPTION
capture sciyoshi/redmine-slack#144 PR:

> Following error is raised under redmine 4 (rails 5):
> 
> ```
> NoMethodError: undefined method `to_prepare' for ActionDispatch::Callbacks:Class
> Did you mean?  to_param
> /path/to/redmine-4.0/plugins/redmine_slack/init.rb:26:in `<top (required)>'
> ```
> 
> Rails 5.1 removed ActionDispatch::Callbacks#to_prepare (see [rails/rails@3f2b7d6](https://github.com/rails/rails/commit/3f2b7d60a52ffb2ad2d4fcf889c06b631db1946b)); so, use ActiveSupport::Reloader for Redmine4 to make this plugin compatible with redmine4.

