### PR TITLE
Fix  issue update notification

### DIFF
--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -7,7 +7,7 @@ module RedmineSlack
 			base.class_eval do
 				unloadable # Send unloadable so it will not be unloaded in development
 				after_create :create_from_issue
-				after_update :save_from_issue
+				after_update_commit :save_from_issue
 			end
 		end
 


### PR DESCRIPTION
## Phenomenon

If you don't enter a comment when updating a ticket
Slack will not be notified if you do not enter a comment when updating a ticket.

### Cause.

Active Recod's `after_update` callback does not
The `after_update` callback in Active Recod does not contain the journal details and
The details are determined to be empty and Slack is not notified.

### Remedy

Change the Active Recod callback to `after_update_commit` and change the callback to `after_update_commit`.
Active Recod callback has been changed to `after_update_commit` so that ticket updates are notified correctly.


